### PR TITLE
Make next release: ps-0.12.x-v0.7.1

### DIFF
--- a/21-Hello-World/07-Application-Structure/ReadMe.md
+++ b/21-Hello-World/07-Application-Structure/ReadMe.md
@@ -4,3 +4,7 @@ The upcoming folders will document the three ways one can structure an applicati
 - MTL (Monad Transforms Library)
 - Free
 - OO code in FP syntax
+
+### A Word of Thanks
+
+While trying to learn this myself, I benefited from looking at the code in stepchownfun's BSD-3 licensed project, [`effects`](https://github.com/stepchowfun/effects), as a guide when I did not completely understand something myself.

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/02-Monad-State/02-Monad-State-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/02-Monad-State/02-Monad-State-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadState where
+module ComputingWithMonads.MonadState where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/03-Ask-and-Reader/02-Monad-Ask-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/03-Ask-and-Reader/02-Monad-Ask-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadAsk where
+module ComputingWithMonads.MonadAsk where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/03-Ask-and-Reader/03-Monad-Reader-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/03-Ask-and-Reader/03-Monad-Reader-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadReader where
+module ComputingWithMonads.MonadReader where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/04-Tell-and-Writer/02-Monad-Tell-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/04-Tell-and-Writer/02-Monad-Tell-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadTell where
+module ComputingWithMonads.MonadTell where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/04-Tell-and-Writer/03-Monad-Writer-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/04-Tell-and-Writer/03-Monad-Writer-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadWriter where
+module ComputingWithMonads.MonadWriter where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/05-Throw-and-Error/02-Monad-Throw-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/05-Throw-and-Error/02-Monad-Throw-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadThrow where
+module ComputingWithMonads.MonadThrow where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/05-Throw-and-Error/03-Monad-Error-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/05-Throw-and-Error/03-Monad-Error-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadError where
+module ComputingWithMonads.MonadError where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/06-Monad-Cont/03-Monad-Cont-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/06-Monad-Cont/03-Monad-Cont-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadCont where
+module ComputingWithMonads.MonadCont where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/01-How-Monad-Trans-Works.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/01-How-Monad-Trans-Works.md
@@ -1,5 +1,7 @@
 # How MonadTrans Works
 
+## Reviewing Old Ideas
+
 Thus far, we've overviewed individual Monad Transformers. However, we have not yet combined them into a stack that allows us to write anything useful. It's now time to reveal this. It will look similar to something we've seen before:
 ```purescript
 class LiftSourceIntoTargetMonad sourceMonad targetMonad where {-
@@ -22,7 +24,7 @@ class LiftSIntoT s t where
   liftSource :: forall a. s ~> t
 ```
 
-# How MonadTrans works
+## Explaining Its Process
 
 1. Define a type class (e.g. `MonadState`) that is only implemented by one monad (e.g. `StateT`)
 2. Define a type class (e.g. `MonadTrans`) that enables one monad to be lifted into another monad

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/01-How-Monad-Trans-Works.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/01-How-Monad-Trans-Works.md
@@ -37,7 +37,7 @@ class LiftSIntoT s t where
 
 Looking at those implementations above, we can see a general pattern (there are some exceptions to this due to how the types need to be handled, but this is generally true):
 - Require one of the types in the instance to be an instance of `MonadState`
-- Implement it by lifting that instance into the monad and delegate its implementation to that instance
+- Implement it by lifting that instance into the monad and delegate that monad's implementation to that instance
 
 Since only `StateT` actually implements `MonadState`, all other monads merely "transform" the `StateT` monad into some other target monad that is closer to the top of the stack. Likwise, since only `[Word]T` actually implements `Monad[Word]`, everything else is just lifting `[Word]T` into another monad that's closer to the top of the stack.
 

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/01-How-Monad-Trans-Works.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/01-How-Monad-Trans-Works.md
@@ -1,0 +1,42 @@
+# How MonadTrans Works
+
+Thus far, we've overviewed individual Monad Transformers. However, we have not yet combined them into a stack that allows us to write anything useful. It's now time to reveal this. It will look similar to something we've seen before:
+```purescript
+class LiftSourceIntoTargetMonad sourceMonad targetMonad where {-
+  liftSourceMonad :: forall a. sourceMonad a -> targetMonad a -}
+  liftSourceMonad ::           sourceMonad   ~> targetMonad
+
+instance box2_into_box1 :: LiftSourceIntoTargetMonad Box2 Box1 where {-
+  liftSourceMonad :: forall a. Box2 a -> Box1 a                      -}
+  liftSourceMonad ::           Box2   ~> Box1
+  liftSourceMonad (Box2 a) = Box1 a
+```
+When we introduced `LiftSourceIntoTargetMonad`, we mentioned that implementing this idea for two monads might be much more complicated than the above implementation. Why? Because we were referring to the newtyped function monads we explained in this folder (not exactly something you want to introduce to a new learner immediately).
+
+We stated beforehand that `MonadState` is only implemented by `StateT`. Because of `bind`'s type requirements, if we want to write a program that uses `MonadState` and another type class introduced in this folder (e.g. `MonadReader`), we'll need to define a way to run/lift the latter monad into the former. However, the direction should go both ways (former lifted into latter and latter lifted into former). Moreover, it would be best to define only one way to lift a number of different monads into the same target monad. Thus, this notion is abstracted into the type class, `MonadTrans`:
+```purescript
+class MonadTrans t where
+  lift :: forall m a. Monad m => m a -> t m a
+
+class LiftSIntoT s t where
+  liftSource :: forall a. s ~> t
+```
+
+# How MonadTrans works
+
+1. Define a type class (e.g. `MonadState`) that is only implemented by one monad (e.g. `StateT`)
+2. Define a type class (e.g. `MonadTrans`) that enables one monad to be lifted into another monad
+3. To enable multiples monads to run in one monad (e.g. `StateT`), implement `MonadTrans` for that monad (e.g. [StateT's instance](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/State/Trans.purs#L95))
+4. To grant multiple monads the capabilities of one monad (e.g. `StateT`), make those other monads implement the one monad's type class (e.g. `MonadState`) in a special way (see below for a pattern):
+    - [ReaderT's MonadState Implementation](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Reader/Trans.purs#L106)
+    - [WriterT's MonadState Implementation](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Writer/Trans.purs#L115)
+    - [ExceptT's MonadState Implementation](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Except/Trans.purs#L124)
+    - [ContT's MonadState Implementation](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Cont/Trans.purs#L68)
+
+Looking at those implementations above, we can see a general pattern (there are some exceptions to this due to how the types need to be handled, but this is generally true):
+- Require one of the types in the instance to be an instance of `MonadState`
+- Implement it by lifting that instance into the monad and delegate its implementation to that instance
+
+Since only `StateT` actually implements `MonadState`, all other monads merely "transform" the `StateT` monad into some other target monad that is closer to the top of the stack. Likwise, since only `[Word]T` actually implements `Monad[Word]`, everything else is just lifting `[Word]T` into another monad that's closer to the top of the stack.
+
+In short, this type class enables us to use all of the functions from each type class explained in this folder

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/02-Using-Monad-Trans.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/02-Using-Monad-Trans.md
@@ -1,0 +1,212 @@
+# Using MonadTrans
+
+When we wrote code for our `MonadState` example, we had something that looked like this:
+```purescript
+type Output = Int
+type StateType = Int
+function :: State StateType Output
+function = do
+  modify_ (_ + 1)
+  modify_ (_ * 10)
+  modify_ (_ + 1)
+
+main :: Effect Unit
+main = case runState function 0 of
+  Tuple output state -> do
+    log $ "Result of computation: " <> show output
+    log $ "End state of computation: " <> show state
+```
+The above code works because we're using `MonadState` behind the scenes via `StateT`'s instance. However, this function's type signature restricts us to only using `StateT` for computations. If we want to augment `function` with functions from `MonadWriter`, we'll need to use a different approach. Let's fix this one step at a time.
+
+First, we'll abstract our `State` type into `MonadState` by using a type constraint:
+```purescript
+type Output = Int
+type StateType = Int
+function :: forall m => MonadState StateType m => m Output
+function = do
+  modify_ (_ + 1)
+  modify_ (_ * 10)
+  modify_ (_ + 1)
+
+-- use a helper function to tell the type inferer that
+-- `function`'s `m` type is `StateT`
+runProgram :: State StateType Output -> Tuple Output StateType
+runProgram s = runState s 0
+
+main :: Effect Unit
+main = case runProgram function of
+  Tuple string state -> do
+    log $ "Result of computation: " <> string
+    log $ "End state of computation: " <> show state
+```
+
+Second, we'll add another type class constraint for `MonadAsk` to expose it's `tell` function:
+```purescript
+type Output = Int
+type StateType = Int
+type NonOutputData = String
+function :: forall m
+          . MonadState StateType m
+         => MonadAsk NonOuputData m
+         => m Output
+function = do
+  modify_ (_ + 1)
+  tell "Modified state by adding 1"
+  currentState <- modify (_ * 10)
+  tell $ "Modified state by multiplying by 10. It is now "
+    <> show currentState
+  modify_ (_ + 1)
+```
+Great! We now have a single function that can do both state manipulation and use `tell`. However, how does that affect `runProgram`?
+```purescript
+runProgram :: StateT_and_WriterT -> StateT_and_WriterT_Output
+runProgram s = -- ???
+```
+
+When we used a monad (e.g. `WriterT`) to run a computation, we didn't need to specify the monad type being used. So, we used `Identity` as a placeholder monad and used the type alias, `Writer`, to make it easier to write. To use another computational monad (e.g. `StateT`) inside of `Writer`, we now need to specify what that monad is by re-exposing the `T` part of `WriterT` and replacing `Identity` with `StateT`:
+```purescript
+-- simple writer computation
+writer :: Writer NonOutputData Output -> Tuple NonOuputData Output
+writer w = runWriter w
+
+-- re-expose the T part of WriterT
+writer :: WriterT NonOutputData Identity Output -> Tuple NonOuputData Output
+writer w = runWriter w
+
+-- swap `Identity` with a type alias called Computation
+type Computation = Identity
+writer :: WriterT NonOutputData Computation Output -> Tuple NonOuputData Output
+writer w = runWriterT w
+
+-- Since the types will get long soon, break up the type signature
+type Computation = Identity
+writer :: WriterT NonOutputData Computation Output
+       -> Tuple NonOuputData Output
+writer w = runWriterT w
+
+-- StateT with its T exposed but set to Identity still
+state :: StateT State Identity Output -> Tuple Output State
+state s = runState s initialState
+
+-- re-alias Computation to StateT
+-- and use `runWriterT` instead of `runWriter`
+type Computation = StateT State Identity Output
+writer :: WriterT NonOutputData Computation Output
+       -> Tuple NonOuputData Output
+writer w = runWriterT w
+
+-- getting rid of the type alias and inlining its type
+-- and rename the function's name to 'runProgram'
+runProgram :: WriterT NonOutputData (StateT State Identity stateOutput) Output
+           -> finalOutput
+runProgram ws = ???
+
+-- Realizing that `StateT` with all three of its types specified
+-- now has kind "Type" and is thus no longer a monad ("Type -> Type"),
+-- we remove the `stateOutput` type to increase
+-- StateT's kind from "Type" to "Type -> Type", making it a monad again
+-- so that it satisfies WriterT's monadic type requirement
+runProgram :: WriterT NonOutputData (StateT State Identity) Output
+           -> finalOutput
+runProgram ws = ???
+
+-- To run StateT, we also need an `initialState` argument. Let's add it
+runProgram :: WriterT NonOutputData (StateT State Identity) Output
+           -> State
+           -> finalOutput
+runProgram ws initialState = ???
+```
+A few questions arise as we do this:
+1. What should `finalOutput`'s type be if we combine the two monad transformers together?
+2. How should `program`'s body be implemented?
+
+The types give us a few clues for a top-down explanation. First (answering question 2), we realize that `State`'s monad type is still `Identity` since no other monad type is inside of `StateT`. Thus, we know that we'll need to use `runState` to unpack its results. Using this line of reasoning, we'll also need to use `runWriterT` instead of `runWriter` because the `WriterT` type is using a non-`Identity` monad.
+
+That leaves us with two possible options:
+- `runWriterT (runState ws initialState)`
+- `runState (runWriterT ws) initialState`
+
+Second (answering question 1), we know that running a `StateT` returns `Tuple stateOutput state` and running a `WriterT` returns `Tuple writerOutput nonOutputData`. That means we'll likely get something close to one of these options:
+1. Both outputs are returned using a Tuple that groups them together:
+    - `Tuple (Tuple stateOutput state) (Tuple writerOutput nonOutputData)` (or vice versa in its order)
+2. The output of one monad is the `stateOutput` (a) or `writerOutput` (b) of the other:
+    - a: `Tuple (Tuple writerOutput nonOutputData) state`
+    - b: `Tuple (Tuple stateOutput  state        ) nonOutputData`
+
+Since we're running one monad inside of another, the second option seems more likely.
+
+The question is, which one is correct?
+
+Let's continue by examining `runStateT`/`runState` and `runWriterT`/`runWriter`. We know that `runMonad` is just a wrapper around `runMonadT` when the monad is `Identity`:
+```purescript
+newtype StateT s m a =
+  StateT (s -> m (Tuple a s))
+
+runState :: StateT state Identity output -> state -> Tuple output state
+runState s initialState = unwrapIdentity $ runStateT s initialState
+
+runStateT :: StateT state monad output -> state -> monad Tuple output state
+runStateT (StateT function) initialState = function initialState
+
+newtype WriterT w m a =
+  WriterT (m (Tuple a w))
+
+runWriter :: WriterT nonOutputData Identity output -> Tuple output nonOutputData
+runWriter w = unwrapIdentity $ runWriterT w
+
+runWriterT :: WriterT nonOutputData monad output -> monad Tuple output nonOutputData
+runWriterT w = w
+```
+They key takeaway here is that `run[Monad]T` returns the same monad that is specified in `[Monad]T`. Looking at our function again...
+```purescript
+runProgram :: WriterT NonOutputData (StateT State Identity) Output
+           -> State
+           -> finalOutput
+runProgram ws initialState = ???
+```
+... running the `WriterT NonOuputData monad output` via `runWriterT` will return its `monad` type. Since that monad type is `StateT State Identity Output`, we will take the output of running `WriterT` (which outputs a `StateT`) and run the output via `runState` since `StateT`'s monad type is `Identity`:
+```purescript
+runProgram :: WriterT NonOutputData (StateT State Identity) Output
+           -> finalOutput
+runProgram ws = runState (runWriterT ws) initialState
+```
+That answers the second question (how to implement `runProgram`), but it still leaves us wondering what `finalOutput` is. This is easier to determine if we just look at `runState` and `runWriterT` again:
+```purescript
+runWriterT :: WriterT nonOutputData monad output -> monad Tuple output nonOutputData
+
+-- reducing `monad Tuple output nonOutputData` to something easier, `m a`
+type A = Tuple output nonOutputData
+runWriterT :: WriterT nonOutputData monad output -> monad A
+
+-- specializing `monad` to `StateT State identity`
+type A = Tuple output nonOutputData
+runWriterT :: WriterT nonOutputData (StateT state Identity) output
+           -> (StateT state Identity A)
+
+-- re-exposing the `a` in `StateT`
+runWriterT :: WriterT nonOutputData (StateT state Identity) output
+           -> (StateT state Identity (Tuple output nonOutputData))
+
+-- Looking at what `runState` returns, we see
+runState :: StateT state Identity output -> state -> Tuple output state
+
+-- Replacing StateT's `output` type with `Tuple output NonOuputData`
+-- we get this:
+runState :: StateT state Identity (Tuple writerOutput nonOutputData)
+         -> state
+         -> Tuple (Tuple writerOutput nonOutputData) state
+
+-- Thus, runProgram's type signature is:
+runProgram :: WriterT NonOutputData (StateT State Identity Output) Output
+           -> State
+           -> Tuple (Tuple output NonOuputData) State
+runProgram ws initialState =
+  runState (runWriterT ws) initialState
+
+-- hidng `StateT`'s monad type, `Identity`, gets us this:
+runProgram :: WriterT NonOutputData (State state) Output
+           -> state
+           -> Tuple (Tuple Output NonOuputData) state
+runProgram ws initialState =
+  runState (runWriterT ws) initialState
+```

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/03-Identifying-the-Pattern.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/11-Using-a-Monad-Transformer/03-Identifying-the-Pattern.md
@@ -1,0 +1,51 @@
+# Identifying The Pattern
+
+You will want to bookmark this page.
+
+Generalizing the idea we discovered in the previous file into a pattern, we get something like this:
+```purescript
+program :: forall m
+         . MonadState StateType m
+        => MonadWriter NonOutputData m
+     -- => other needed type classes here in any order...
+        => m ProgramFinalOutputType
+program = do
+  -- use all the functions from the type classes
+
+--  StateT state         monad output
+-- "IndexN possibleInput monad typeClassOutput"
+runProgram :: Index3 input3 (       -- bottom of the stack
+                Index2 input2 (
+                  Index1 input1 (
+                    Index0 input0   -- =
+                      Identity      -- | top of the stack (just a function)
+                    output0         -- =
+                  ) output1
+                ) output2
+              ) output3
+        -- -> input0      -- =
+        -- -> input1      -- | all needed initial
+        -- -> input2      -- | args go here
+        -- -> input3      -- =
+           -> Tuple (
+                Tuple (
+                  Tuple (
+                    Tuple (
+                      computationOutput
+                      output3
+                    )
+                    output2
+                  )
+                  output1
+                )
+                output0
+              )
+runProgram computation {- args -} =
+  runIndex0 (                               -- top of the stack
+    runIndex1T (
+      runIndex2T (
+        runIndex3T computation index3Args   -- bottom of the stack
+      ) index2Args
+    ) index1Args
+  ) index0Args
+```

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/12-Monad-Trans/01-Monad-Trans.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/12-Monad-Trans/01-Monad-Trans.md
@@ -1,0 +1,20 @@
+# Monad Trans
+
+`MonadTrans` enables one computational monad to run inside another, thereby exposing multiple type class' functions for usage in `bind`/`>>=` / do notation in the same function. It enables one to write an entire program via newtyped function monads (or functions with monadic syntax).
+
+```purescript
+class MonadTrans t where
+  lift :: forall m a. m a -> t m a
+```
+
+## Laws
+
+[See its docs](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.Trans.Class#t:MonadTrans)
+
+## Instances
+
+- [StateT](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/State/Trans.purs#L95)
+- [ReaderT](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Reader/Trans.purs#L83)
+- [WriterT](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Writer/Trans.purs#L91)
+- [ExceptT](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Except/Trans.purs#L99)
+- [ContT](https://github.com/purescript/purescript-transformers/blob/v4.1.0/src/Control/Monad/Cont/Trans.purs#L54)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/12-Monad-Trans/02-Monad-Trans-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/12-Monad-Trans/02-Monad-Trans-Example.purs
@@ -1,0 +1,38 @@
+module ComputingWithMonads.Example.MonadTrans where
+
+import Prelude
+import Effect (Effect)
+import Effect.Console (log)
+
+import Data.Tuple (Tuple(..))
+
+-- State
+import Control.Monad.State.Class (class MonadState, get, gets, modify_)
+import Control.Monad.State (State, runState)
+
+-- Writer
+import Control.Monad.Writer.Class (class MonadWriter, tell)
+import Control.Monad.Writer.Trans (WriterT, runWriterT)
+
+program :: forall m. MonadState Int m => MonadWriter String m => m String
+program = do
+    currentState <- get
+    tell $ "Current State is now: " <> show currentState
+    modify_ (_ + 10)
+    gets show
+
+run :: forall a. WriterT String (State Int) a
+    -> Int
+    -> Tuple (Tuple a String) Int
+run function initialState = runState (runWriterT function) initialState
+
+main :: Effect Unit
+main = case run program 0 of
+  Tuple (Tuple output nonOutputData) nextState -> do
+    log $ "Finished!"
+    log $ "(Computation) final output: " <> show output
+    log $ "(Writer)   non-output data: " <> show nonOutputData
+    log $ "(State)         next state: " <> show nextState
+
+    let (Tuple (Tuple o _ ) _ ) = run program 8
+    log $ "Using pattern matching to get the computation's output: " <> show o

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/12-Monad-Trans/02-Monad-Trans-Example.purs
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/12-Monad-Trans/02-Monad-Trans-Example.purs
@@ -1,4 +1,4 @@
-module ComputingWithMonads.Example.MonadTrans where
+module ComputingWithMonads.MonadTrans where
 
 import Prelude
 import Effect (Effect)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/13-Other-Monad-Transformers.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/13-Other-Monad-Transformers.md
@@ -1,0 +1,15 @@
+# Other Monad Transformers
+
+## Usable Now
+
+- [RWS](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.RWS.Trans#t:RWST) a convenience monad that combines `ReaderT`, `WriterT`, and `StateT` into the same monad type
+- [ListT](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.List.Trans#t:ListT), a monad that returns a `List a`. In addition, it provides the regular list functions you'd expect
+- [MaybeT](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.Maybe.Trans#t:MaybeT), a monad the returns a `Maybe a`
+
+## Requires More Understanding
+
+- [CoMonadTrans](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Comonad.Trans.Class), the Transformer type class for Comonads.
+- [CoMonadTraced](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Comonad.Traced.Class#t:ComonadTraced)
+- [CoMonadStore](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Comonad.Store.Class)
+- [CoMonadAsk](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Comonad.Env.Class#t:ComonadAsk)
+- [CoMonadEnv](https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Comonad.Env.Class#t:ComonadEnv)

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/14-Summary.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/14-Summary.md
@@ -1,0 +1,20 @@
+# Summary
+
+What follows is my general understanding of what is true by this point in my learning process. It might be inaccurate or misleading, so take it with a grain of salt.
+
+What did we gain by doing this? Let's give an overview:
+- A program that is one pure function composed of many smaller pure functions.
+- Since we're using `newtype`s everywhere, the code we're writing doesn't incur any runtime overhead from boxing/unboxing a monad via bind. If it is slower than OO code, the compiler may not be doing as many optimizations as it could be, or that might be the cost of using immutable data structures.
+- Since the same input will always produce the same output, it makes our program easier to test and debug.
+- Refactoring our code should be trivial.
+
+I'm not sure how accurate this table is, but it's a pattern I noticed after finishing this folder.
+
+| A basic concept... | ...becomes a monad transformer via |
+| - | - |
+| Either e a | ExceptT
+| Tuple a b | WriterT
+| Maybe a | MaybeT
+| List a | ListT
+| f $ arg | ContT
+| state manipulation | StateT

--- a/21-Hello-World/07-Application-Structure/src/01-MTL/ReadMe.md
+++ b/21-Hello-World/07-Application-Structure/src/01-MTL/ReadMe.md
@@ -74,7 +74,7 @@ So, how do we get around this limitation?
 
 We saw the same problem earlier when we wanted to run an `Effect` monad inside of a `Box` monad. We fixed it by "lifting" the `Effect` monad into the `Box` monad via a [`NaturalTransformation`](https://pursuit.purescript.org/packages/purescript-prelude/4.1.0/docs/Data.NaturalTransformation#t:NaturalTransformation)/`~>`. This was abstracted into a type class specific for `Effect ~> someOtherMonad` in [`MonadEffect`](https://pursuit.purescript.org/packages/purescript-effect/2.0.0/docs/Effect.Class#t:MonadEffect).
 
-Following that idea, we can define a `NaturalTransformation` between one computational monad (e.g. `MonadReader`) into another computational monad (e.g. `MonadState`) by implementing a function with this type signature: `MonadReader ~> MonadState`. Using a visual, it produces this diagram (read from bottom to top):
+Following that idea, we can define **something similar to** a `NaturalTransformation` that "lifts" one computational monad (e.g. `MonadReader`) into another computational monad (e.g. `MonadState`). Using a visual, it produces this diagram (read from bottom to top):
 ```
 MonadState_TargetMonad
       ^
@@ -82,7 +82,7 @@ MonadState_TargetMonad
       |
 MonadReader_SourceMonad
 ```
-If we want to use all of the monads above, we must ultimately create a "stack" of `NaturalTransformation`s that lifts one monad type somewhere in the "stack" all the way up and into the monad type at the top of the stack. Using a visual, it produces this diagram (read from bottom to top):
+If we want to use all of the monads above, we must ultimately create a "stack" of these monad transformations that lift one monad type somewhere in the "stack" all the way up and into the monad type at the top of the stack. Using a visual, it produces this diagram (read from bottom to top):
 ```
 Index0_TopMonad
       ^
@@ -106,16 +106,6 @@ Index4_NextMonad
       |
 Index5_BottomMonad
 ```
-In other words, there are five `NaturalTransformation` functions...:
-1. `Index5 ~> Index4`
-2. `Index4 ~> Index3`
-3. `Index3 ~> Index2`
-4. `Index2 ~> Index1`
-5. `Index1 ~> Index0`
-
-... that produces a data type like:
-```purescript
-Index0 (Index1 (Index2 (Index3 (Index4 (Index5 someDataType)))))
-```
+This idea will be covered more when we explain what `MonadTrans` is and how it works
 
 This approach to functional programming is called "**Monad Transformers**" or "**mtl**" (short for 'monad transformers library', referring to the original Haskell library that synthesized this discovered idea into code).


### PR DESCRIPTION
## New Content

- Explain how to combine multiple monad transformers into one final program via `MonadTrans` (though more things could be explained, this finishes #58)
- Add a word of thanks to project for his code (helped me understand how to use a monad transformer stack)

## Fixes

- Correct misunderstanding: a stack of monad transformers is not a stack of `monad1 ~> monad2`
- One would need to write `pulp --psc-package run -m Module.Example.MonadState` to run the examples. I removed the `Example` submodule since it was boilerplate.