### PR TITLE
Added link to Functional Design Patterns slideshare

### DIFF
--- a/31-Design-Patterns/ReadMe.md
+++ b/31-Design-Patterns/ReadMe.md
@@ -2,6 +2,8 @@
 
 This folder is still a work-in-progress!
 
+Scott Wlaschin, a FP expert warns that [Functional Design patterns](https://www.slideshare.net/ScottWlaschin/functional-design-patterns-devternity2018) are very different from Object Oriented patterns (the F# examples are easy to translate into PureScript).
+
 See [the related issues](https://github.com/JordanMartinez/purescript-jordans-reference/issues?q=is%3Aissue+is%3Aopen+label%3ADesign-Patterns) regarding this folder for a more up-to-date understanding.
 
 See also this list of [Functional Pearls](https://wiki.haskell.org/Research_papers/Functional_pearls)


### PR DESCRIPTION
I think the resource link itself is great. Maybe it would be worth to create (sub-)sections about the following patterns:
- Composition is everywhere (Composition is fractal + Types can be composed too)
- Use static types for Domain  modelling and documentation => Would be relevant to have a dedicated section about Domain Driven Design with FP (and summarize the book 'Domain Modeling Made Functional')
- Use Bind to chain tasks and error handlers