### PR TITLE
Some typo in Chapter Hello-World/Application-Structure/MTL/Foundations

### DIFF
--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/01-The-Function-Monad.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/01-The-Function-Monad.md
@@ -84,7 +84,7 @@ class Functor (Function input) where
          (originalOutput -> newOutput) ->
          Function input originalOutput -> Function input newOutput
   map originalToNew f = (\input ->
-    let originalOutput = f argument
+    let originalOutput = f input
     in {- remaining body of function -} )
 ```
 
@@ -95,7 +95,7 @@ class Functor (Function input) where
          (originalOutput -> newOutput) ->
          Function input originalOutput -> Function input newOutput
   map originalToNew f = (\input ->
-    let originalOutput = f argument
+    let originalOutput = f input
     in originalToNew originalOutput)
 ```
 

--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/01-The-Function-Monad.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/01-The-Function-Monad.md
@@ -77,7 +77,7 @@ class Functor (Function inputType) where
   map originalToNew f = (\input -> {- remaining body of function -} )
 ```
 
-2. Since `f` is the only function that can "receive" a value of type, `input`, we have to pass that value into `f`. `f` will produce `originalOutputValue`, so let's store that in a let binding:
+2. Since `f` is the only function that can "receive" a value of type, `input`, we have to pass that value into `f`. `f` will produce `originalOutput`, so let's store that in a let binding:
 ```purescript
 class Functor (Function inputType) where
   map :: forall originalOutputType newOutputType.
@@ -88,7 +88,7 @@ class Functor (Function inputType) where
     in {- remaining body of function -} )
 ```
 
-3. Since `originalTonew` is the only function that can "receive" a value of type, `originalOutput`, we have to pass the value outputted by `f` into that function. `originalTonew` produces a value of the type, `newOutput`, which gives us the return value of our created function:
+3. Since `originalToNew` is the only function that can "receive" a value of type, `originalOutput`, we have to pass the value outputted by `f` into that function. `originalToNew` produces a value of the type, `newOutput`, which gives us the return value of our created function:
 ```purescript
 class Functor (Function inputType) where
   map :: forall originalOutputType newOutputType.
@@ -112,7 +112,7 @@ class Functor (Function inputType) where
   map = (<<<)
 ```
 
-In real code, normally we could use `a`, `b` as type variable. Therefore, the above snippet will be simplfied to
+In real code, normally we use `a`, `b` as type variable. Therefore, the above snippet will be simplfied to
 ```purescript
 class Functor (Function i) where
   map :: forall a b. (a -> b) -> Function i a -> Function i b
@@ -138,7 +138,7 @@ class (Functor f) <= Apply f where
 Again, let's take this slowly. Notice first the first argument, what should the full type signature of `f (a -> b)` be if `f` is `Function`? Since the `f` has to be the same for both situations, then `f` has to be `Function input`. In other words, the first argument is a function that returns another function:
 ```purescript
 class (Functor (Function inputType)) <= Apply (Function inputType) where
-  apply :: forall a b. f (a -> b) -> f a -> f b
+  apply :: forall originalOutputType newOutputType.
            Function inputType (originalOutputType -> newOutputType) ->
            Function inputType  originalOutputType ->
            Function inputType  newOutputType
@@ -151,7 +151,7 @@ Let's see how to implement this function.
 1. Since `apply` returns a new function, let's start creating one using lambda syntax:
 ```purescript
 class (Functor (Function inputType)) <= Apply (Function inputType) where
-  apply :: forall a b. f (a -> b) -> f a -> f b
+  apply :: forall originalOutputType newOutputType.
            Function inputType (originalOutputType -> newOutputType) ->
            Function inputType  originalOutputType ->
            Function inputType  newOutputType
@@ -161,10 +161,10 @@ class (Functor (Function inputType)) <= Apply (Function inputType) where
 2. At this point, both `f` and `functionInFunction` can receive an value of type, `input`. For right now, let's do what we did last time and only pass it into `f`. We'll store the output in a let binding:
 ```purescript
 class (Functor (Function inputType)) <= Apply (Function inputType) where
-  apply :: forall a b. f (a -> b) -> f a -> f b
+  apply :: forall originalOutputType newOutputType.
            Function inputType (originalOutputType -> newOutputType) ->
            Function inputType  originalOutputType ->
-           Function inputType newOutputType
+           Function inputType  newOutputType
   apply functionInFunction f = (\input ->
     let originalOutput = f input
     in {- body of function -})
@@ -173,10 +173,10 @@ class (Functor (Function inputType)) <= Apply (Function inputType) where
 3. At this point, the only way to get map `originalOutput` into `newOutput` is to pass it into the function that's hidden in `functionInFunction`. How do we get that out? We can pass `input` into that function. Again, we'll store that output in a let binding:
 ```purescript
 class (Functor (Function inputType)) <= Apply (Function inputType) where
-  apply :: forall a b. f (a -> b) -> f a -> f b
+  apply :: forall originalOutputType newOutputType.
            Function inputType (originalOutputType -> newOutputType) ->
            Function inputType  originalOutputType ->
-           Function inputType newOutputType
+           Function inputType  newOutputType
   apply functionInFunction f = (\input ->
     let
       originalOutput = f input
@@ -187,10 +187,10 @@ class (Functor (Function inputType)) <= Apply (Function inputType) where
 4. We now have all the pieces we need to return `newOutput`. Let's pass `originalOutput` into `originalTonew`:
 ```purescript
 class (Functor (Function inputType)) <= Apply (Function inputType) where
-  apply :: forall a b. f (a -> b) -> f a -> f b
+  apply :: forall originalOutputType newOutputType.
            Function inputType (originalOutputType -> newOutputType) ->
            Function inputType  originalOutputType ->
-           Function inputType newOutputType
+           Function inputType  newOutputType
   apply functionInFunction f = (\input ->
     let
       originalOutput = f input
@@ -201,10 +201,10 @@ class (Functor (Function inputType)) <= Apply (Function inputType) where
 Great! Can we clean it up now?
 ```purescript
 class (Functor (Function inputType)) <= Apply (Function inputType) where
-  apply :: forall a b. f (a -> b) -> f a -> f b
+  apply :: forall originalOutputType newOutputType.
            Function inputType (originalOutputType -> newOutputType) ->
            Function inputType  originalOutputType ->
-           Function inputType newOutputType
+           Function inputType  newOutputType
   apply functionInFunction f = (\input -> (functionInFunction input) (f input))
 ```
 

--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/02-Do-Notation-for-Monadic-Functions.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/02-Do-Notation-for-Monadic-Functions.md
@@ -12,7 +12,7 @@ class Functor (Function inputType) where
          Function inputType originalOutputType ->
          Function inputType newOutputType
   map originalToNew f = (\input ->
-    let originalOutput = f argument
+    let originalOutput = f input
     in originalToNew originalOutput)
 
 class (Functor (Function inputType)) <= Apply (Function inputType) where

--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/02-Do-Notation-for-Monadic-Functions.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/02-Do-Notation-for-Monadic-Functions.md
@@ -6,19 +6,20 @@ This file will help you learn how to read a monadic function's "do notation." We
 
 To help us evaluate these examples manually, we'll include our verbose "not cleaned up" solutions from the previous file here (except for the `Applicative` one):
 ```purescript
-class Functor (Function input) where
-  map :: forall originalOutput newOutput.
-         (originalOutput -> newOutput) ->
-         Function input originalOutput -> Function input newOutput
+class Functor (Function inputType) where
+  map :: forall originalOutputType newOutputType.
+         (originalOutputType -> newOutputType) ->
+         Function inputType originalOutputType ->
+         Function inputType newOutputType
   map originalToNew f = (\input ->
     let originalOutput = f argument
     in originalToNew originalOutput)
 
-class (Functor (Function input)) <= Apply (Function input) where
-  apply :: forall originalOutput newOutput.
-           Function input (originalOutput -> newOutput) ->
-           Function input  originalOutput ->
-           Function input newOutput
+class (Functor (Function inputType)) <= Apply (Function inputType) where
+  apply :: forall originalOutputType newOutputType.
+           Function inputType (originalOutputType -> newOutputType) ->
+           Function inputType  originalOutputType ->
+           Function inputType  newOutputType
   apply functionInFunction f = (\input ->
     let
       originalOutput = f input
@@ -27,15 +28,15 @@ class (Functor (Function input)) <= Apply (Function input) where
 
 -- Since pure ignores its argument, I'll use the cleaned up version
 -- here because it's easier to understand
-class (Apply (Function input)) <= Applicative (Function input) where
-  pure :: forall output. output -> Function input output
+class (Apply (Function inputType)) <= Applicative (Function inputType) where
+  pure :: forall outputType. outputType -> Function inputType outputType
   pure value = (\_ -> value)
 
-class (Apply (Function input)) <= Bind (Function input) where
-  bind :: forall originalOutput newOutput.
-          (originalOutput -> Function input newOutput) ->
-          Function input originalOutput ->
-          Function input newOutput
+class (Apply (Function inputType)) <= Bind (Function inputType) where
+  bind :: forall originalOutputType newOutputType.
+          (originalOutputType -> Function inputType newOutputType) ->
+          Function inputType originalOutputType ->
+          Function inputType newOutputType
   bind originalToFunction f = (\input ->
     let
       originalOutput = f input

--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/03-Special-Output.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/03-Special-Output.md
@@ -361,6 +361,6 @@ If we were to generalize our function to a monad, it would look like this:
 ```purescript
 newtype OutputMonad a m b = (a -> m b)
 
-runOutputMonad :: forall m a b. Monad m => Ouput a m b -> a -> m b
+runOutputMonad :: forall m a b. Monad m => OutputMonad a m b -> a -> m b
 runOutputMonad (OutputMonad function) arg = function arg
 ```

--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/04-Introducing-Monad-Transformers.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/04-Introducing-Monad-Transformers.md
@@ -36,8 +36,8 @@ produceComputation = runOutputEffect someComputation 4
   someComputation = do
     five <- (\four -> pure $ 1 + four)
     three <- (\fourAgain -> pure $ 7 - fourAgain)
-    intBetween0And2 <- (\fourOnceMore -> randomInt 0 $ 13 + fourOnceMore - five)
-    (\fourTooMany -> log $ show $ 8 - intBetween0And2)
+    intBetween0And12 <- (\fourOnceMore -> randomInt 0 $ 13 + fourOnceMore - five)
+    (\fourTooMany -> log $ show $ 8 - intBetween0And12)
 ```
 
 But what if we expressed the same idea using capabilities via type class constraints? This is the same code as above:
@@ -47,13 +47,13 @@ produceComputation = runOutputMonad someComputation 4
   someComputation :: forall m. Monad m =>
                      MonadReader Int m =>
                      MonadEffect m =>
-                     m String
+                     OutputMonad Int m String
   someComputation = do
     four <- ask
     let five = 1 + four
     let three = 7 - four
-    intBetween0And2 <- liftEffect $ randomInt 0 $ 13 + four - five
-    liftEffect $ log $ show $ 8 - intBetween0And2
+    intBetween0And12 <- liftEffect $ randomInt 0 $ 13 + four - five
+    liftEffect $ log $ show $ 8 - intBetween0And12
 ```
 
 ## Introducing `ReaderT`


### PR DESCRIPTION
Fixes: #435

## 01-The-Function-Monad.md
- fixed a typo. update `argument` to `input`
- updated type name with suffix `Type`

## 02-Do-Notation-for-Monadic-Functions.md
- did the same thing in this file

## 03-Special-Output.md 
- minor updates, updated monad name from `Ouput` to `OutputMonad`

## 04-Introducing-Monad-Transformers.md
- updated var `intBetween0And2` to `intBetween0And12`
- updated `someComputation` signature, return `OutputMonad`