### PR TITLE
Expand and clarify derive newtype & Newtype instance

### DIFF
--- a/11-Syntax/01-Basic-Syntax/src/03-TypeClasses-and-Newtypes/22-Deriving-Typeclass-Instances-for-Newtyped-Types.purs
+++ b/11-Syntax/01-Basic-Syntax/src/03-TypeClasses-and-Newtypes/22-Deriving-Typeclass-Instances-for-Newtyped-Types.purs
@@ -2,8 +2,8 @@ module Syntax.Basic.Deriving.Newtype where
 
 import Prelude
 
--- needed for 2nd approach
-import Data.Newtype (class Newtype)
+-- needed for deriving Newtype example
+import Data.Newtype (class Newtype, over)
 
 -- License applies to a portion of this document --> Start
 
@@ -31,10 +31,10 @@ newtype FirstName = FirstName String
 
 -- This is boilerplate since we unpack the instance and delegate the function
 -- to the wrapped type's implementation. It's also inefficient in terms of
--- evaluation. So, we have a better way to do this.
--- We use add 'derive newtype' in front of the instance:
+-- evaluation. Purescript gives us a way to derive, for newtypes, any instance
+-- the boxed type implements, using the following syntax.
+-- We use 'derive newtype' in front of the instance:
 
--- 1st approach
 newtype EmailAddress2 = EmailAddress2 String
 
 derive newtype instance eqEmailAddress2 :: Eq EmailAddress2
@@ -52,9 +52,7 @@ derive newtype instance eqFirstName :: Eq FirstName
 -- Licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
 --   https://creativecommons.org/licenses/by-nc-sa/3.0/deed.en_US
 
--- 2nd approach
-
--- Another approach is by using the `newtype` library: purescript-newtype
+-- Another useful class we can derive from is found in the `newtype` library: purescript-newtype
 class Newtype_ new old | new -> old where
   wrap_ :: old -> new
   unwrap_ :: new -> old
@@ -64,7 +62,10 @@ newtype EmailAddress3 = EmailAddress3 String
 -- no need to indicate what "_" is since the compiler can figure it out
 derive instance newtypeEmailAddress :: Newtype EmailAddress3 _
 
--- Newtype provides other useful functions.
+-- Data.Newtype provides other useful functions that lets us avoid manually
+-- wrapping and unwrapping. For example:
+upperEmail :: EmailAddress -> EmailAddress
+upperEmail = over EmailAddress toUpper
 -- To see the full list, look at the package's docs:
 -- https://pursuit.purescript.org/packages/purescript-newtype/3.0.0/docs/Data.Newtype
 -- <--- End


### PR DESCRIPTION
While reworking this section I removed `1st appraoch`/`2nd approach` mentions since it seemed to me that they imply that they're exclusive, but they're actually complementary.

Like you don't get `Eq` instance for free if you just derive instance `Newtype`. So hopefully this PR clarifies a bit this stuff.

Fixes #474 
