### PR TITLE
Fixed topic 'Building This Project'

### DIFF
--- a/.ci/install-build-test-all.sh
+++ b/.ci/install-build-test-all.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# This script performs all the steps to install, build, and test
+# the example programs for this project.
+#
+# Run this from the root of this project:
+#
+#   source .ci/install-build-test-all.sh
+
+source .ci/spago--install.sh
+source .ci/spago--build-and-test.sh

--- a/.ci/spago--build-and-test.sh
+++ b/.ci/spago--build-and-test.sh
@@ -1,13 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 
-# This file uses `spago` to build/test each folder's contents
-# The exit code from the build/test command is stored via "$?"
-# At the end of this file, all exit codes are displayed and this shell
-# exits with 0 if everything worked correctly. Otherwise, it exits with 1.
+# This script uses `spago` to build/test each folder's contents.
 #
-# Run this from the root of this project. In other words
-#   `chmod +x .travis/spago--build-and-test.sh`
-#   `./.travis/spago--build-and-test.sh`
+# A user should use this script to build and test the example programs
+# and tests.  When this script finishes, it will output a concise summary
+# of each build/test's success or failure, and finally deliver a prominent
+# announcement whether this script was completely successful or had any
+# failures.
 
 ## Syntax
 
@@ -163,29 +162,27 @@ echo "$HELLO_TLP - Hello World - Type-Level Programming"
 echo "$HELLO_TESTING - Hello World - Testing"
 echo "$HELLO_BENCHMARK - Hello World - Benchmarking"
 
-if [ $SYNTAX_BASIC == 0 ] &&
-   [ $SYNTAX_FFI == 0 ] &&
-   [ $SYNTAX_TLP == 0 ] &&
-   [ $SYNTAX_MODULE == 0 ] &&
-   [ $SYNTAX_PRELUDE == 0 ] &&
-   [ $SYNTAX_DO_ADO_NOTATION == 0 ] &&
-   [ $HELLO_EFFECT_AND_AFF == 0 ] &&
-   [ $HELLO_DEBUGGING == 0 ] &&
-   [ $HELLO_COLLECTIONS_LOOPS == 0 ] &&
-   [ $HELLO_APP_STRUCT_BUILT_OK == 0 ] &&
-   [ $HELLO_EXAMPLE_HELLO_WORLD_READERT == 0 ] &&
-   [ $HELLO_EXAMPLE_HELLO_WORLD_FREE == 0 ] &&
-   [ $HELLO_EXAMPLE_HELLO_WORLD_RUN == 0 ] &&
-   [ $HELLO_EXAMPLE_NUMBER_COMPARISON_READERT == 0 ] &&
-   [ $HELLO_EXAMPLE_NUMBER_COMPARISON_FREE == 0 ] &&
-   [ $HELLO_EXAMPLE_NUMBER_COMPARISON_RUN == 0 ] &&
-   [ $HELLO_TLP == 0 ] &&
-   [ $HELLO_TESTING == 0 ] &&
-   [ $HELLO_BENCHMARK == 0 ]
+if [ $SYNTAX_BASIC = 0 ] &&
+   [ $SYNTAX_FFI = 0 ] &&
+   [ $SYNTAX_TLP = 0 ] &&
+   [ $SYNTAX_MODULE = 0 ] &&
+   [ $SYNTAX_PRELUDE = 0 ] &&
+   [ $SYNTAX_DO_ADO_NOTATION = 0 ] &&
+   [ $HELLO_EFFECT_AND_AFF = 0 ] &&
+   [ $HELLO_DEBUGGING = 0 ] &&
+   [ $HELLO_COLLECTIONS_LOOPS = 0 ] &&
+   [ $HELLO_APP_STRUCT_BUILT_OK = 0 ] &&
+   [ $HELLO_EXAMPLE_HELLO_WORLD_READERT = 0 ] &&
+   [ $HELLO_EXAMPLE_HELLO_WORLD_FREE = 0 ] &&
+   [ $HELLO_EXAMPLE_HELLO_WORLD_RUN = 0 ] &&
+   [ $HELLO_EXAMPLE_NUMBER_COMPARISON_READERT = 0 ] &&
+   [ $HELLO_EXAMPLE_NUMBER_COMPARISON_FREE = 0 ] &&
+   [ $HELLO_EXAMPLE_NUMBER_COMPARISON_RUN = 0 ] &&
+   [ $HELLO_TLP = 0 ] &&
+   [ $HELLO_TESTING = 0 ] &&
+   [ $HELLO_BENCHMARK = 0 ]
 then
-  echo "Build Succeeded"
-  exit 0;
+  echo "***** PASS: All Build Tasks and Tests Succeeded *****"
 else
-  echo "Build Failed"
-  exit 1;
+  echo "***** FAIL: At Least One Build Task or Test Failed *****"
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,4 @@ jobs:
         run: |
           chmod +x .ci/spago--build-and-test.sh
           ./.ci/spago--build-and-test.sh
+          exit

--- a/01-Getting-Started/04-Install-Guide.md
+++ b/01-Getting-Started/04-Install-Guide.md
@@ -44,28 +44,40 @@ Unlike the manual install, `nvm` properly handles the npm prefix for you. So, yo
 #### Installing PureScript and Related Tooling
 
 Once you have installed `npm`, we can use it to install everything in one command:
-```bash
+
+```sh
 npm i -g purescript@0.14.3 spago@0.20.3 parcel
 ```
 
 If you want to install a PureScript formatter, refer to their instructions. The history behind these tools will be covered in the `Build Tools` folder:
+
 - [purs-tidy](https://github.com/natefaubion/purescript-tidy) - A self-contained formatter written in PureScript
 - [pose](https://pose.rowtype.yoga/) - A plugin written in PureScript for the [`Prettier`](https://prettier.io/) formatter
 
 ### Versions Used in this Project
 
 The following commands should now work (the versions beside them are the versions I used when writing this project):
-```bash
-purs --version        # 0.14.3
-spago version         # 0.20.3
-parcel --version      # 1.12.4
+
+```sh
+purs --version        # 0.14.4 -- works through 0.14.5 as well
+spago --version       # 0.20.3
+parcel --version      # 1.12.4 -- works through 2.00-rc0 as well
 ```
 
 ### Building This Project
 
-Once the above has been verified, run the below script, which will download, install, and build every folder in this project. Open a shell in this project's parent folder and run this command:
-```bash
-./for-each-folder--install-deps-and-compile.sh
+Once the above has been verified, you can build this project.
+
+First of all, if you haven't yet cloned this project locally, then do so now:
+
+```sh
+git clone https://github.com/JordanMartinez/purescript-jordans-reference
+```
+
+Then execute the script below which will install, build, and test every folder in this project:
+
+```sh
+source .ci/install-build-test-all.sh
 ```
 
 Whenever I make a new release with breaking changes, this script will remove any outdated dependencies, reinstall the correct ones, and rebuild all of the folders' code.


### PR DESCRIPTION
Fixes: #575

1. Rebuilt this capability
2. Cleaned up the install/build/test reporting.
3. In script `spago--build-and-test.sh`, changed compare operator `==` to `=` and made is a `sh` script instead of a `bash` script to upgrade to fix a MacOS **Catalina** syntax incompatibility.

The above changes were made so that continuous integration facility's functionality was left unchanged.  The edits look more extensive than they really are in that I had to move large chunks of the shell code from one script to another.
