### PR TITLE
Fix 01-The-Function-Monad.md typo

### DIFF
--- a/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/01-The-Function-Monad.md
+++ b/21-Hello-World/05-Application-Structure/src/02-MTL/01-Foundations.md/01-The-Function-Monad.md
@@ -363,7 +363,7 @@ class Functor ((->) inputType) where
          (originalOutputType -> newOutputType) ->
          (inputType -> originalOutputType) -> (inputType -> newOutputType)
   map originalToNew f = (\input ->
-    let originalOutput = f argument
+    let originalOutput = f input
     in originalToNew originalOutput)
 
 class (Functor ((->) inputType)) <= Apply ((->) inputType) where


### PR DESCRIPTION
Fix a wrongly named parameter "argument" into correct name "input", which corresponds to the lambda parameter.

Fixes: #612 
